### PR TITLE
Use model_dump_json

### DIFF
--- a/ommx_da4_adapter/client.py
+++ b/ommx_da4_adapter/client.py
@@ -70,7 +70,7 @@ class DA4Client:
         """wrapper of `requests.post`.
 
         :param url: The endpoint path
-        :param serialized_body: The serialized data to be sent in the request body
+        :param serialized_body: JSON string to send as the request body
         :param headers: HTTP request headers
         :return: json dict
         :raises OMMXDA4AdapterError: If an HTTP status other than 200s is returned

--- a/ommx_da4_adapter/client.py
+++ b/ommx_da4_adapter/client.py
@@ -116,9 +116,7 @@ class DA4Client:
         :param blob_account_name: X-Storage-Account-Name. Defaults to None.
         :return: The job ID
         """
-        serialized_body = qubo_request.model_dump_json(
-            exclude_none=True, by_alias=True
-        )
+        serialized_body = qubo_request.model_dump_json(exclude_none=True, by_alias=True)
 
         if (blob_sas_token is not None) and (blob_account_name is not None):
             da4_headers = {

--- a/ommx_da4_adapter/models.py
+++ b/ommx_da4_adapter/models.py
@@ -207,3 +207,6 @@ class QuboSolutionList(pydantic.BaseModel):
 class QuboResponse(pydantic.BaseModel):
     qubo_solution: QuboSolutionList
     status: Literal["Done", "Deleted"]
+
+class JobID(pydantic.BaseModel):
+    job_id: str

--- a/ommx_da4_adapter/models.py
+++ b/ommx_da4_adapter/models.py
@@ -208,5 +208,6 @@ class QuboResponse(pydantic.BaseModel):
     qubo_solution: QuboSolutionList
     status: Literal["Done", "Deleted"]
 
+
 class JobID(pydantic.BaseModel):
     job_id: str

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -278,7 +278,7 @@ class TestDA4Client(unittest.TestCase):
         mock_post.assert_called_once_with(
             "/v4/async/jobs/cancel",
             JobID(job_id=job_id).model_dump_json(),
-            self.expected_headers
+            self.expected_headers,
         )
         self.assertTrue(result)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,7 @@ from ommx_da4_adapter.models import (
     BinaryPolynomial,
     BinaryPolynomialTerm,
     FujitsuDA3Solver,
+    JobID,
     QuboRequest,
 )
 
@@ -85,7 +86,7 @@ class TestDA4Client(unittest.TestCase):
         mock_response.json.return_value = {"test": "data"}
         mock_post.return_value = mock_response
 
-        test_data = {"key": "value"}
+        test_data = json.dumps({"key": "value"})
         test_headers = {"header": "value"}
 
         result = self.client.post("/test/endpoint", test_data, test_headers)
@@ -93,7 +94,7 @@ class TestDA4Client(unittest.TestCase):
         mock_post.assert_called_once_with(
             self.url + "/test/endpoint",
             headers=test_headers,
-            data=json.dumps(test_data),
+            data=test_data,
         )
         self.assertEqual(result, {"test": "data"})
 
@@ -106,7 +107,7 @@ class TestDA4Client(unittest.TestCase):
         mock_response.text = "Error message"
         mock_post.return_value = mock_response
 
-        test_data = {"key": "value"}
+        test_data = json.dumps({"key": "value"})
         test_headers = {"header": "value"}
 
         with self.assertRaises(OMMXDA4AdapterError):
@@ -160,7 +161,7 @@ class TestDA4Client(unittest.TestCase):
 
         mock_post.assert_called_once_with(
             "/v4/async/qubo/solve",
-            qubo_request.model_dump(exclude_none=True, by_alias=True),
+            qubo_request.model_dump_json(exclude_none=True, by_alias=True),
             self.expected_headers,
         )
         self.assertEqual(result, "test-job-id")
@@ -202,7 +203,7 @@ class TestDA4Client(unittest.TestCase):
 
         mock_post.assert_called_once_with(
             "/v4/async/qubo/solve",
-            qubo_request.model_dump(exclude_none=True, by_alias=True),
+            qubo_request.model_dump_json(exclude_none=True, by_alias=True),
             expected_headers,
         )
         self.assertEqual(result, "test-job-id")
@@ -275,7 +276,9 @@ class TestDA4Client(unittest.TestCase):
         result = self.client.post_job_cancel(job_id)
 
         mock_post.assert_called_once_with(
-            "/v4/async/jobs/cancel", {"job_id": job_id}, self.expected_headers
+            "/v4/async/jobs/cancel",
+            JobID(job_id=job_id).model_dump_json(),
+            self.expected_headers
         )
         self.assertTrue(result)
 
@@ -287,7 +290,9 @@ class TestDA4Client(unittest.TestCase):
         result = self.client.post_job_cancel(job_id)
 
         mock_post.assert_called_once_with(
-            "/v4/async/jobs/cancel", {"job_id": job_id}, self.expected_headers
+            "/v4/async/jobs/cancel",
+            JobID(job_id=job_id).model_dump_json(),
+            self.expected_headers,
         )
         self.assertFalse(result)
 


### PR DESCRIPTION
Modified to use `model_dump_json`. Because using `pydantic.BaseModel.model_dump_json` is 6-7 times faster than `json.dumps` when serializing the request body.